### PR TITLE
Wessam611 focal loss kwargs (#1)

### DIFF
--- a/cbloss/loss.py
+++ b/cbloss/loss.py
@@ -46,20 +46,21 @@ class FocalLoss(nn.Module):
         Focal loss value.
     """
 
-    def __init__(self, num_classes, alpha=1, gamma=2, reduction="mean"):
+    def __init__(self, num_classes, alpha=1, gamma=2, reduction="mean", **kwargs):
         super(FocalLoss, self).__init__()
         self.num_classes = num_classes
         self.alpha = alpha
         self.gamma = gamma
         self.reduction = reduction
+        self.kwargs = kwargs
 
     def forward(self, outputs, targets):
         if self.num_classes == 2:
             # binary classification problem
-            ce_loss = F.binary_cross_entropy_with_logits(outputs, targets.float(), reduction="none")
+            ce_loss = F.binary_cross_entropy_with_logits(outputs, targets.float(), reduction="none", **self.kwargs)
         elif self.num_classes > 2:
             # multi-class classification problem
-            ce_loss = F.cross_entropy(outputs, targets, reduction="none")
+            ce_loss = F.cross_entropy(outputs, targets, reduction="none", **self.kwargs)
         else:
             raise ValueError(f"Invalid input value : {self.num_classes}. It should be equal or greater than 2.")
 


### PR DESCRIPTION
Feat: enable **kwargs in FocalLoss which are being passed to Torch's cross entropy functions

example key: ignore_index